### PR TITLE
Fix image URLs in unit tests and example app

### DIFF
--- a/Example/ImageKit/FetchImageViewController.swift
+++ b/Example/ImageKit/FetchImageViewController.swift
@@ -39,21 +39,23 @@ class FetchImageViewController: UIViewController {
     }
     
     @IBAction func OnClickTransformation3(_ sender: Any) {
-        guard let url = try? ImageKit.shared.url(src: "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg", transformationPosition: TransformationPosition.PATH)
+        guard let url = try? ImageKit.shared.url(urlEndpoint: "https://ik.imagekit.io/demo/img", path: "/medium_cafe_B1iTdD0C.jpg", transformationPosition: TransformationPosition.PATH)
+            .raw(params: "l-text,i-logo-white_SJwqB4Nfe.png,ox-10,l-end")
             .setResponsive(view: imageView)
             .create() else { return }
         self.showImage(url: url)
     }
     
     @IBAction func OnClickTransformation4(_ sender: Any) {
-        let url = ImageKit.shared.url(src: "https://ik.imagekit.io/demo/tr:oi-logo-white_SJwqB4Nfe.png,ox-N10,oy-20/medium_cafe_B1iTdD0C.jpg")
-            .raw(params: "l-text,i-ik_logo.png,lx-20,ly-20,r-32,l-end")
+        let url = ImageKit.shared.url(src: "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
+            .raw(params: "l-image,i-logo-white_SJwqB4Nfe.png,lx-N20,ly-20,l-end")
             .create()
         self.showImage(url: url)
     }
     
     @IBAction func OnClickTransformation5(_ sender: Any) {
-        let url = ImageKit.shared.url(src: "https://ik.imagekit.io/demo/img/plant.jpeg?tr=oi-logo-white_SJwqB4Nfe.png,ox-10,oy-20")
+        let url = ImageKit.shared.url(src: "https://ik.imagekit.io/demo/img/plant.jpeg")
+            .raw(params: "l-text,i-Hand%20with%20a%20green%20plant,co-264120,fs-30,lx-10,ly-20,l-end")
             .addCustomTransformation(key: "w", value: "400")
             .create()
         self.showImage(url: url)

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -537,6 +537,13 @@ class UnitTestSpec: QuickSpec {
                     .create()
                 expect(actual).to(equal(String(format: "https://ik.imagekit.io/demo/tr:w-300/medium_cafe_B1iTdD0C.jpg")))
             }
+            it("With raw transforms string") {
+                let actual = ImageKit.shared
+                    .url(src: "https://ik.imagekit.io/demo/img/plant.jpeg")
+                    .raw(params: "w-400:l-text,i-Hand%20with%20a%20green%20plant,co-264120,fs-30,lx-10,ly-20,l-end")
+                    .create()
+                expect(actual).to(equal("https://ik.imagekit.io/demo/img/plant.jpeg?tr=w-400:l-text,i-Hand%20with%20a%20green%20plant,co-264120,fs-30,lx-10,ly-20,l-end"))
+            }
         }
         
         describe("Image Path with Transformations height: 300, width: 300 and rotate: 90") {
@@ -591,13 +598,6 @@ class UnitTestSpec: QuickSpec {
                     .rotation(rotation: Rotation.VALUE_90)
                     .create()
                 expect(actual).to(equal(String(format: "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg?tr=h-300,w-300:rt-90")))
-            }
-            it("With raw transforms string") {
-                let actual = ImageKit.shared
-                    .url(src: "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
-                    .raw(params: "h-300,w-300,rt-90")
-                    .create()
-                expect(actual).to(equal(String(format: "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg?tr=h-300,w-300,rt-90")))
             }
             it("Empty URL") {
                 let actual = ImageKit.shared


### PR DESCRIPTION
- Modify the image URLs in unit tests for raw transforms method to fix the layer syntax.
- Modify the image URLs with overlay transforms to replace them with the layer syntax for overlays.